### PR TITLE
Fix: Added heroTag to FloatingActionButton to prevent Hero conflict

### DIFF
--- a/lib/src/map_location_picker.dart
+++ b/lib/src/map_location_picker.dart
@@ -601,6 +601,7 @@ class _MapLocationPickerState extends State<MapLocationPicker> {
                   Padding(
                     padding: const EdgeInsets.all(8.0),
                     child: FloatingActionButton(
+                      heroTag: "map_type_fab",
                       onPressed: null,
                       tooltip: 'Map Type',
                       backgroundColor: Theme.of(context).primaryColor,
@@ -641,6 +642,7 @@ class _MapLocationPickerState extends State<MapLocationPicker> {
                   Padding(
                     padding: const EdgeInsets.all(8.0),
                     child: FloatingActionButton(
+                      heroTag: "set_current_location_fab",
                       tooltip: widget.fabTooltip,
                       backgroundColor: Theme.of(context).primaryColor,
                       foregroundColor: Theme.of(context).colorScheme.onPrimary,


### PR DESCRIPTION
Fixed an issue where multiple FloatingActionButtons in the navigation tree
caused the error "There are multiple heroes that share the same tag".
Assigned a unique heroTag to each FAB.